### PR TITLE
fix(ci): remove build deps from publish tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -329,31 +329,44 @@ tasks:
   # =============================================================================
 
   publish:js:
-    desc: "Upload Node.js prebuilds to GitHub Releases"
+    desc: "Upload Node.js prebuilds to GitHub Releases (assumes prebuilds exist)"
+    cmds:
+      - node scripts/publish.js --node
+
+  publish:js:full:
+    desc: "Build and upload Node.js prebuilds to GitHub Releases"
     deps: [prebuild:js]
     cmds:
       - node scripts/publish.js --node
 
   publish:js:linux:
-    desc: "Upload Node.js prebuilds for Linux to GitHub Releases"
-    deps: [prebuild:js:linux]
+    desc: "Upload Node.js prebuilds for Linux to GitHub Releases (assumes prebuilds exist)"
     cmds:
       - node scripts/publish.js --node --platform linux
 
   publish:js:darwin:
-    desc: "Upload Node.js prebuilds for macOS to GitHub Releases"
-    deps: [prebuild:js:darwin]
+    desc: "Upload Node.js prebuilds for macOS to GitHub Releases (assumes prebuilds exist)"
     cmds:
       - node scripts/publish.js --node --platform darwin
 
   publish:py:
-    desc: "Upload Python wheels to PyPI"
-    deps: [build:py, build:py:linux]
+    desc: "Upload Python wheels to PyPI (assumes wheels exist in dist/py)"
     cmds:
       - node scripts/publish.js --python --prod
 
   publish:py:test:
-    desc: "Upload Python wheels to TestPyPI"
+    desc: "Upload Python wheels to TestPyPI (assumes wheels exist in dist/py)"
+    cmds:
+      - node scripts/publish.js --python --test
+
+  publish:py:full:
+    desc: "Build and upload Python wheels to PyPI"
+    deps: [build:py, build:py:linux]
+    cmds:
+      - node scripts/publish.js --python --prod
+
+  publish:py:test:full:
+    desc: "Build and upload Python wheels to TestPyPI"
     deps: [build:py, build:py:linux]
     cmds:
       - node scripts/publish.js --python --test


### PR DESCRIPTION
---
name: Pull Request
about: Submit changes to the RTMS SDK
---

## Description
The publish:js task had deps on prebuild:js which triggered a full rebuild during CI publish. This failed because the SDK isn't installed in the publish job - it only downloads pre-built artifacts.

Removed build dependencies from publish tasks since CI handles the build/publish separation. Added :full variants for local development where the full build→publish flow is needed.

## Related Issues
Fixes #(issue number)

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests (adding or improving tests)
- [x] Build changes

## Affected Components
- [ ] Core C++ implementation
- [ ] Node.js bindings
- [ ] Python bindings
- [ ] Go bindings
- [x] Build system
- [ ] Documentation
- [ ] Examples
- [ ] Other (please specify)

## Testing Performed
Describe the tests you ran to verify your changes. Include relevant details such as test configuration and instructions to reproduce.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Context
Add any other context about the PR here.