### PR TITLE
Release 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.3] - 2026-02-17
 
+### Added
+
+- **Webinar support**: Added `webinar_uuid` parameter to `join()` for Zoom Webinar events (`webinar.rtms_started`); priority: `meeting_uuid` > `webinar_uuid` > `session_id`
+- **`onMediaConnectionInterrupted` callback**: New high-level callback for `EVENT_MEDIA_CONNECTION_INTERRUPTED` events with auto-subscription (Node.js and Python)
+
 ### Fixed
 
 - **Release crash on ended sessions**: `release()` no longer throws when the meeting has already ended externally; cleanup always completes and `RTMS_SDK_NOT_EXIST` is treated as success ([#93](https://github.com/zoom/rtms/issues/93))
 - **Video params ignored after audio params**: Calling `setAudioParams()` before `setVideoParams()` no longer overwrites video configuration with defaults; individual param setters skip the default-filling logic ([#94](https://github.com/zoom/rtms/issues/94))
 - **Express middleware compatibility**: `createWebhookHandler` now reads from `req.body` when pre-parsed by middleware (e.g., `express.json()`), preventing hangs when the request stream has already been consumed ([#96](https://github.com/zoom/rtms/issues/96))
 - **Webhook schema validation**: Webhook handlers (Node.js and Python) now validate that the `event` field is present in the payload and return 400 Bad Request for invalid payloads ([#95](https://github.com/zoom/rtms/issues/95))
+- **Python event callback coexistence**: Refactored to shared event dispatcher so `onParticipantEvent`, `onActiveSpeakerEvent`, and `onSharingEvent` can all be registered simultaneously (previously each overwrote the last)
 
 ## [1.0.2] - 2026-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Zoom RTMS SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-02-17
+
+### Fixed
+
+- **Release crash on ended sessions**: `release()` no longer throws when the meeting has already ended externally; cleanup always completes and `RTMS_SDK_NOT_EXIST` is treated as success ([#93](https://github.com/zoom/rtms/issues/93))
+- **Video params ignored after audio params**: Calling `setAudioParams()` before `setVideoParams()` no longer overwrites video configuration with defaults; individual param setters skip the default-filling logic ([#94](https://github.com/zoom/rtms/issues/94))
+- **Express middleware compatibility**: `createWebhookHandler` now reads from `req.body` when pre-parsed by middleware (e.g., `express.json()`), preventing hangs when the request stream has already been consumed ([#96](https://github.com/zoom/rtms/issues/96))
+- **Webhook schema validation**: Webhook handlers (Node.js and Python) now validate that the `event` field is present in the payload and return 400 Bad Request for invalid payloads ([#95](https://github.com/zoom/rtms/issues/95))
+
 ## [1.0.2] - 2026-01-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ For detailed contribution guidelines, build instructions, and troubleshooting, s
 
 ## Usage
 
+> **Speaker Identification with Mixed Audio**
+>
+> When using `AUDIO_MIXED_STREAM` (the default), all participants are mixed into a single audio stream and the audio callback's metadata will **not** identify the current speaker. To identify who is speaking, register an `onActiveSpeakerEvent` callback — it fires whenever the active speaker changes. See [Troubleshooting #7](#7-identifying-speakers-with-mixed-audio-streams) and [#80](https://github.com/zoom/rtms/issues/80) for details.
+
 ### Node.js - Webhook Integration
 
 Easily respond to Zoom webhooks and connect to RTMS streams:

--- a/index.ts
+++ b/index.ts
@@ -964,6 +964,7 @@ class Client extends nativeRtms.Client {
 
     const {
       meeting_uuid,
+      webinar_uuid,
       session_id,
       rtms_stream_id,
       server_urls,
@@ -974,12 +975,12 @@ class Client extends nativeRtms.Client {
       pollInterval = 0
     } = options;
 
-    // Use meeting_uuid for Meeting SDK events, session_id for Video SDK events
-    const instance_id = meeting_uuid || session_id;
+    // Use meeting_uuid for Meeting SDK, webinar_uuid for Webinar, session_id for Video SDK
+    const instance_id = meeting_uuid || webinar_uuid || session_id;
 
     this.pollRate = pollInterval;
 
-    Logger.info('client', `Joining ${meeting_uuid ? 'meeting' : 'session'}: ${instance_id}`, {
+    Logger.info('client', `Joining ${meeting_uuid ? 'meeting' : webinar_uuid ? 'webinar' : 'session'}: ${instance_id}`, {
       streamId: rtms_stream_id,
       serverUrls: server_urls,
       timeout: providedTimeout,
@@ -987,7 +988,7 @@ class Client extends nativeRtms.Client {
     });
 
     if (!instance_id) {
-      throw new Error('Either meeting_uuid or session_id must be provided');
+      throw new Error('Either meeting_uuid, webinar_uuid, or session_id must be provided');
     }
 
     const finalSignature = providedSignature || generateSignature({

--- a/index.ts
+++ b/index.ts
@@ -862,6 +862,7 @@ class Client extends nativeRtms.Client {
   private activeSpeakerEventCallback: ((timestamp: number, userId: number, userName: string) => void) | null = null;
   private sharingEventCallback: ((event: 'start' | 'stop', timestamp: number, userId?: number, userName?: string) => void) | null = null;
   private rawEventCallback: ((eventData: string) => void) | null = null;
+  private mediaConnectionInterruptedCallback: ((timestamp: number) => void) | null = null;
   private eventHandlerRegistered: boolean = false;
 
   constructor() {
@@ -935,6 +936,12 @@ class Client extends nativeRtms.Client {
                 'stop',
                 data.timestamp || 0
               );
+            }
+            break;
+
+          case nativeRtms.EVENT_MEDIA_CONNECTION_INTERRUPTED:
+            if (this.mediaConnectionInterruptedCallback) {
+              this.mediaConnectionInterruptedCallback(data.timestamp || 0);
             }
             break;
         }
@@ -1136,6 +1143,34 @@ class Client extends nativeRtms.Client {
       super.subscribeEvent([nativeRtms.EVENT_SHARING_START, nativeRtms.EVENT_SHARING_STOP]);
     } catch (e) {
       Logger.warn('client', `Failed to auto-subscribe to sharing events: ${e}`);
+    }
+
+    return true;
+  }
+
+  /**
+   * Register a callback for media connection interrupted events
+   *
+   * This automatically subscribes to EVENT_MEDIA_CONNECTION_INTERRUPTED.
+   *
+   * @param callback Function called when the media connection is interrupted
+   * @returns true if registration succeeds
+   *
+   * @example
+   * ```typescript
+   * client.onMediaConnectionInterrupted((timestamp) => {
+   *   console.log(`Media connection interrupted at ${timestamp}`);
+   * });
+   * ```
+   */
+  onMediaConnectionInterrupted(callback: (timestamp: number) => void): boolean {
+    this.mediaConnectionInterruptedCallback = callback;
+    this.setupEventHandler();
+
+    try {
+      super.subscribeEvent([nativeRtms.EVENT_MEDIA_CONNECTION_INTERRUPTED]);
+    } catch (e) {
+      Logger.warn('client', `Failed to auto-subscribe to media connection interrupted events: ${e}`);
     }
 
     return true;

--- a/index.ts
+++ b/index.ts
@@ -246,6 +246,8 @@ function exposeNumberConstants(nativeModule: any): Record<string, number> {
     'MEDIA_TYPE_TRANSCRIPT', 'MEDIA_TYPE_CHAT', 'MEDIA_TYPE_ALL',
     // Session events
     'SESSION_EVENT_ADD', 'SESSION_EVENT_STOP', 'SESSION_EVENT_PAUSE', 'SESSION_EVENT_RESUME',
+    // User events
+    'USER_JOIN', 'USER_LEAVE',
     // Event types (for subscribeEvent/onEventEx)
     'EVENT_UNDEFINED', 'EVENT_FIRST_PACKET_TIMESTAMP', 'EVENT_ACTIVE_SPEAKER_CHANGE',
     'EVENT_PARTICIPANT_JOIN', 'EVENT_PARTICIPANT_LEAVE',

--- a/index.ts
+++ b/index.ts
@@ -453,23 +453,20 @@ export function createWebhookHandler(callback: WebhookCallbackUnion, path: strin
       return;
     }
 
-    let body = '';
-    req.on('data', chunk => body += chunk.toString());
-
-    req.on('end', () => {
+    const processPayload = (body: string) => {
       try {
         Logger.debug('webhook', `Received webhook request: ${req.url}`);
         const payload = JSON.parse(body);
-        
+
         // Log the webhook event
         Logger.info('webhook', `Received event: ${payload.event || 'unknown'}`, {
           eventType: payload.event,
           payloadSize: body.length
         });
-        
+
         // Check if this is a raw webhook callback
         const isRawCallback = isRawWebhookCallback(callback);
-        
+
         if (isRawCallback) {
           // For raw callbacks, pass req and res objects
           process.nextTick(() => {
@@ -493,7 +490,7 @@ export function createWebhookHandler(callback: WebhookCallbackUnion, path: strin
               Logger.error('webhook', `Error in webhook callback: ${err instanceof Error ? err.message : 'Unknown error'}`);
             }
           });
-          
+
           res.writeHead(200, headers);
           res.end(JSON.stringify({ status: 'ok' }));
         }
@@ -502,7 +499,19 @@ export function createWebhookHandler(callback: WebhookCallbackUnion, path: strin
         res.writeHead(400, headers);
         res.end(JSON.stringify({ error: 'Invalid JSON received' }));
       }
-    });
+    };
+
+    // Check if body was already parsed by middleware (e.g., express.json())
+    if ((req as any).body !== undefined) {
+      const body = typeof (req as any).body === 'string'
+        ? (req as any).body
+        : JSON.stringify((req as any).body);
+      processPayload(body);
+    } else {
+      let body = '';
+      req.on('data', chunk => body += chunk.toString());
+      req.on('end', () => processPayload(body));
+    }
   };
 }
 

--- a/index.ts
+++ b/index.ts
@@ -460,7 +460,15 @@ export function createWebhookHandler(callback: WebhookCallbackUnion, path: strin
       try {
         Logger.debug('webhook', `Received webhook request: ${req.url}`);
         const payload = JSON.parse(body);
-        
+
+        // Validate required webhook fields
+        if (!payload.event || typeof payload.event !== 'string') {
+          Logger.warn('webhook', 'Received webhook payload missing required "event" field');
+          res.writeHead(400, headers);
+          res.end(JSON.stringify({ error: 'Invalid webhook payload: missing required "event" field' }));
+          return;
+        }
+
         // Log the webhook event
         Logger.info('webhook', `Received event: ${payload.event || 'unknown'}`, {
           eventType: payload.event,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoom/rtms",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Node.js Wrapper for the Zoom RTMS C SDK",
   "main": "./build/Release/index.js",
   "types": "rtms.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "rtms"
-version = "1.0.2"
+version = "1.0.3"
 description = "Python bindings for the Zoom RTMS C SDK - Real-Time Media Streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/rtms.d.ts
+++ b/rtms.d.ts
@@ -305,14 +305,17 @@ export interface DeskshareParams {
  * Parameters for joining a Zoom RTMS session
  *
  * For Meeting SDK events (meeting.rtms_started), use meeting_uuid.
+ * For Webinar events (webinar.rtms_started), use webinar_uuid.
  * For Video SDK events (session.rtms_started), use session_id.
- * If both are provided, meeting_uuid takes precedence.
+ * Priority: meeting_uuid > webinar_uuid > session_id.
  *
  * @category Common Interfaces
  */
 export interface JoinParams {
   /** The UUID of the Zoom meeting (for Meeting SDK events) */
   meeting_uuid?: string;
+  /** The UUID of the Zoom webinar (for Webinar events) */
+  webinar_uuid?: string;
   /** The session ID (for Video SDK events) - used when meeting_uuid is not provided */
   session_id?: string;
   /** The RTMS stream ID for this connection */

--- a/rtms.d.ts
+++ b/rtms.d.ts
@@ -877,6 +877,23 @@ export class Client {
   onSharingEvent(callback: SharingEventCallback): boolean;
 
   /**
+   * Sets a callback for media connection interrupted events
+   *
+   * This automatically subscribes to EVENT_MEDIA_CONNECTION_INTERRUPTED.
+   *
+   * @param callback The callback function to invoke with the event timestamp
+   * @returns true if the callback was set successfully
+   *
+   * @example
+   * ```typescript
+   * client.onMediaConnectionInterrupted((timestamp) => {
+   *   console.log(`Media connection interrupted at ${timestamp}`);
+   * });
+   * ```
+   */
+  onMediaConnectionInterrupted(callback: (timestamp: number) => void): boolean;
+
+  /**
    * Sets a callback for raw event data
    *
    * This provides access to the raw JSON event data from the SDK.

--- a/src/rtms.cpp
+++ b/src/rtms.cpp
@@ -461,7 +461,7 @@ void Client::uninitialize() {
     rtms_uninit();
 }
 
-void Client::configure(const MediaParams& params, int media_types, bool enable_application_layer_encryption) {
+void Client::configure(const MediaParams& params, int media_types, bool enable_application_layer_encryption, bool apply_defaults) {
     // Store the media parameters for future use
     media_params_ = params;
     enabled_media_types_ = media_types;
@@ -469,25 +469,29 @@ void Client::configure(const MediaParams& params, int media_types, bool enable_a
 
     // If media types are enabled but no params were set, use sensible defaults
     // This ensures proper metadata attribution (e.g., AUDIO_MULTI_STREAMS for audio)
-    if ((media_types & MediaType::AUDIO) && !media_params_.hasAudioParams()) {
+    // Skip defaults when called from setAudioParams/setVideoParams/setDeskshareParams
+    // to avoid prematurely filling in default params for other media types
+    if (apply_defaults) {
+        if ((media_types & MediaType::AUDIO) && !media_params_.hasAudioParams()) {
 #ifdef RTMS_DEBUG
-        cerr << "[DEBUG CONFIG] Audio enabled but no params set, using defaults (AUDIO_MULTI_STREAMS)" << endl;
+            cerr << "[DEBUG CONFIG] Audio enabled but no params set, using defaults (AUDIO_MULTI_STREAMS)" << endl;
 #endif
-        media_params_.setAudioParams(AudioParams());
-    }
+            media_params_.setAudioParams(AudioParams());
+        }
 
-    if ((media_types & MediaType::VIDEO) && !media_params_.hasVideoParams()) {
+        if ((media_types & MediaType::VIDEO) && !media_params_.hasVideoParams()) {
 #ifdef RTMS_DEBUG
-        cerr << "[DEBUG CONFIG] Video enabled but no params set, using defaults" << endl;
+            cerr << "[DEBUG CONFIG] Video enabled but no params set, using defaults" << endl;
 #endif
-        media_params_.setVideoParams(VideoParams());
-    }
+            media_params_.setVideoParams(VideoParams());
+        }
 
-    if ((media_types & MediaType::DESKSHARE) && !media_params_.hasDeskshareParams()) {
+        if ((media_types & MediaType::DESKSHARE) && !media_params_.hasDeskshareParams()) {
 #ifdef RTMS_DEBUG
-        cerr << "[DEBUG CONFIG] Deskshare enabled but no params set, using defaults" << endl;
+            cerr << "[DEBUG CONFIG] Deskshare enabled but no params set, using defaults" << endl;
 #endif
-        media_params_.setDeskshareParams(DeskshareParams());
+            media_params_.setDeskshareParams(DeskshareParams());
+        }
     }
 
     if (!media_params_.hasAudioParams() && !media_params_.hasVideoParams() && !media_params_.hasDeskshareParams()) {
@@ -674,9 +678,10 @@ void Client::setDeskshareParams(const DeskshareParams& ds_params)
     media_params_.setDeskshareParams(ds_params);
 
     // If deskshare is already enabled, reconfigure with the new params
+    // Pass apply_defaults=false to avoid filling in defaults for other media types
     if (enabled_media_types_ & MediaType::DESKSHARE) {
         try {
-            configure(media_params_, enabled_media_types_, false);
+            configure(media_params_, enabled_media_types_, false, false);
         } catch (const Exception& e) {
             cerr << "Warning: Failed to reconfigure deskshare params: " << e.what() << endl;
         }
@@ -691,9 +696,10 @@ void Client::setVideoParams(const VideoParams& video_params)
     media_params_.setVideoParams(video_params);
 
     // If video is already enabled, reconfigure with the new params
+    // Pass apply_defaults=false to avoid filling in defaults for other media types
     if (enabled_media_types_ & MediaType::VIDEO) {
         try {
-            configure(media_params_, enabled_media_types_, false);
+            configure(media_params_, enabled_media_types_, false, false);
         } catch (const Exception& e) {
             cerr << "Warning: Failed to reconfigure video params: " << e.what() << endl;
         }
@@ -708,9 +714,10 @@ void Client::setAudioParams(const AudioParams& audio_params)
     media_params_.setAudioParams(audio_params);
 
     // If audio is already enabled, reconfigure with the new params
+    // Pass apply_defaults=false to avoid filling in defaults for other media types
     if (enabled_media_types_ & MediaType::AUDIO) {
         try {
-            configure(media_params_, enabled_media_types_, false);
+            configure(media_params_, enabled_media_types_, false, false);
         } catch (const Exception& e) {
             cerr << "Warning: Failed to reconfigure audio params: " << e.what() << endl;
         }

--- a/src/rtms.cpp
+++ b/src/rtms.cpp
@@ -568,8 +568,11 @@ void Client::setOnSessionUpdate(SessionUpdateFn callback) {
 }
 
 void Client::setOnUserUpdate(UserUpdateFn callback) {
-    lock_guard<mutex> lock(mutex_);
-    user_update_callback_ = std::move(callback);
+    {
+        lock_guard<mutex> lock(mutex_);
+        user_update_callback_ = std::move(callback);
+    }
+    subscribeEvent({EVENT_ACTIVE_SPEAKER_CHANGE, EVENT_PARTICIPANT_JOIN, EVENT_PARTICIPANT_LEAVE});
 }
 
 void Client::setOnDeskshareData(DsDataFn callback){

--- a/src/rtms.cpp
+++ b/src/rtms.cpp
@@ -758,8 +758,8 @@ void Client::poll() {
 
 void Client::release() {
     int result = rtms_release(sdk_);
-    throwIfError(result, "release");
 
+    // Always clean up, even if release returned an error
     {
         lock_guard<mutex> lock(registry_mutex_);
         sdk_registry_.erase(sdk_);
@@ -774,6 +774,11 @@ void Client::release() {
     }
 
     sdk_ = nullptr;
+
+    // RTMS_SDK_NOT_EXIST means the resource was already released — that's fine
+    if (result != RTMS_SDK_OK && result != RTMS_SDK_NOT_EXIST) {
+        throwIfError(result, "release");
+    }
 }
 
 string Client::uuid() const {

--- a/src/rtms.h
+++ b/src/rtms.h
@@ -266,7 +266,7 @@ public:
 
     static void initialize(const string& ca, int is_verify_cert = 1, const char* agent = nullptr);
     static void uninitialize();
-    void configure(const MediaParams& params, int media_types, bool enable_application_layer_encryption = false);
+    void configure(const MediaParams& params, int media_types, bool enable_application_layer_encryption = false, bool apply_defaults = true);
 
     void enableVideo(bool enable);
     void enableAudio(bool enable);

--- a/src/rtms/__init__.py
+++ b/src/rtms/__init__.py
@@ -573,6 +573,14 @@ class Client(_ClientBase):
         self._running = False
         self._webhook_server = None
 
+        # Shared event dispatcher state (matches Node.js setupEventHandler pattern)
+        self._event_handler_registered = False
+        self._participant_event_callback = None
+        self._active_speaker_callback = None
+        self._sharing_callback = None
+        self._media_interrupted_callback = None
+        self._raw_event_callback = None
+
         # Register with global client registry
         with _clients_lock:
             _clients[id(self)] = self
@@ -855,6 +863,73 @@ class Client(_ClientBase):
         """
         return super().unsubscribeEvent(events)
 
+    def _setup_event_handler(self):
+        """
+        Internal shared event dispatcher that routes events to typed callbacks.
+        Matches the Node.js setupEventHandler() pattern. Only registers once.
+        """
+        if self._event_handler_registered:
+            return
+        self._event_handler_registered = True
+
+        def event_dispatcher(event_data: str):
+            if self._raw_event_callback:
+                self._raw_event_callback(event_data)
+            try:
+                data = json.loads(event_data)
+                event_type = data.get('event_type')
+
+                if event_type == EVENT_PARTICIPANT_JOIN:
+                    if self._participant_event_callback:
+                        participants = [
+                            {'user_id': p.get('user_id'), 'user_name': p.get('user_name')}
+                            for p in data.get('participants', [])
+                        ]
+                        self._participant_event_callback('join', data.get('timestamp', 0), participants)
+
+                elif event_type == EVENT_PARTICIPANT_LEAVE:
+                    if self._participant_event_callback:
+                        participants = [
+                            {'user_id': p.get('user_id'), 'user_name': p.get('user_name')}
+                            for p in data.get('participants', [])
+                        ]
+                        self._participant_event_callback('leave', data.get('timestamp', 0), participants)
+
+                elif event_type == EVENT_ACTIVE_SPEAKER_CHANGE:
+                    if self._active_speaker_callback:
+                        self._active_speaker_callback(
+                            data.get('timestamp', 0),
+                            data.get('user_id', 0),
+                            data.get('user_name', '')
+                        )
+
+                elif event_type == EVENT_SHARING_START:
+                    if self._sharing_callback:
+                        self._sharing_callback(
+                            'start',
+                            data.get('timestamp', 0),
+                            data.get('user_id'),
+                            data.get('user_name')
+                        )
+
+                elif event_type == EVENT_SHARING_STOP:
+                    if self._sharing_callback:
+                        self._sharing_callback(
+                            'stop',
+                            data.get('timestamp', 0),
+                            None,
+                            None
+                        )
+
+                elif event_type == EVENT_MEDIA_CONNECTION_INTERRUPTED:
+                    if self._media_interrupted_callback:
+                        self._media_interrupted_callback(data.get('timestamp', 0))
+
+            except Exception as e:
+                log_error('client', f'Failed to parse event: {e}')
+
+        super().onEventEx(event_dispatcher)
+
     def onParticipantEvent(self, callback: Callable[[str, int, list], None]) -> bool:
         """
         Register a callback for participant join/leave events.
@@ -876,27 +951,8 @@ class Client(_ClientBase):
             ...     print(f"Participant {event}: {participants}")
             >>> client.onParticipantEvent(on_participant)
         """
-        def event_handler(event_data: str):
-            try:
-                data = json.loads(event_data)
-                event_type = data.get('event_type')
-
-                if event_type == EVENT_PARTICIPANT_JOIN:
-                    participants = [
-                        {'user_id': p.get('user_id'), 'user_name': p.get('user_name')}
-                        for p in data.get('participants', [])
-                    ]
-                    callback('join', data.get('timestamp', 0), participants)
-                elif event_type == EVENT_PARTICIPANT_LEAVE:
-                    participants = [
-                        {'user_id': p.get('user_id'), 'user_name': p.get('user_name')}
-                        for p in data.get('participants', [])
-                    ]
-                    callback('leave', data.get('timestamp', 0), participants)
-            except Exception as e:
-                log_error('client', f'Failed to parse participant event: {e}')
-
-        super().onEventEx(event_handler)
+        self._participant_event_callback = callback
+        self._setup_event_handler()
         try:
             self.subscribeEvent([EVENT_PARTICIPANT_JOIN, EVENT_PARTICIPANT_LEAVE])
         except Exception as e:
@@ -920,21 +976,8 @@ class Client(_ClientBase):
             ...     print(f"Active speaker: {user_name} ({user_id})")
             >>> client.onActiveSpeakerEvent(on_speaker)
         """
-        def event_handler(event_data: str):
-            try:
-                data = json.loads(event_data)
-                event_type = data.get('event_type')
-
-                if event_type == EVENT_ACTIVE_SPEAKER_CHANGE:
-                    callback(
-                        data.get('timestamp', 0),
-                        data.get('user_id', 0),
-                        data.get('user_name', '')
-                    )
-            except Exception as e:
-                log_error('client', f'Failed to parse active speaker event: {e}')
-
-        super().onEventEx(event_handler)
+        self._active_speaker_callback = callback
+        self._setup_event_handler()
         try:
             self.subscribeEvent([EVENT_ACTIVE_SPEAKER_CHANGE])
         except Exception as e:
@@ -963,33 +1006,55 @@ class Client(_ClientBase):
             ...     print(f"Sharing {event} by {user_name}")
             >>> client.onSharingEvent(on_sharing)
         """
-        def event_handler(event_data: str):
-            try:
-                data = json.loads(event_data)
-                event_type = data.get('event_type')
-
-                if event_type == EVENT_SHARING_START:
-                    callback(
-                        'start',
-                        data.get('timestamp', 0),
-                        data.get('user_id'),
-                        data.get('user_name')
-                    )
-                elif event_type == EVENT_SHARING_STOP:
-                    callback(
-                        'stop',
-                        data.get('timestamp', 0),
-                        None,
-                        None
-                    )
-            except Exception as e:
-                log_error('client', f'Failed to parse sharing event: {e}')
-
-        super().onEventEx(event_handler)
+        self._sharing_callback = callback
+        self._setup_event_handler()
         try:
             self.subscribeEvent([EVENT_SHARING_START, EVENT_SHARING_STOP])
         except Exception as e:
             log_warn('client', f'Failed to auto-subscribe to sharing events: {e}')
+        return True
+
+    def onMediaConnectionInterrupted(self, callback: Callable[[int], None]) -> bool:
+        """
+        Register a callback for media connection interrupted events.
+
+        This automatically subscribes to EVENT_MEDIA_CONNECTION_INTERRUPTED.
+
+        Args:
+            callback: Function called with (timestamp,) when the media connection is interrupted
+
+        Returns:
+            bool: True if registration succeeds
+
+        Example:
+            >>> def on_interrupted(timestamp):
+            ...     print(f"Media connection interrupted at {timestamp}")
+            >>> client.onMediaConnectionInterrupted(on_interrupted)
+        """
+        self._media_interrupted_callback = callback
+        self._setup_event_handler()
+        try:
+            self.subscribeEvent([EVENT_MEDIA_CONNECTION_INTERRUPTED])
+        except Exception as e:
+            log_warn('client', f'Failed to auto-subscribe to media connection interrupted events: {e}')
+        return True
+
+    def onEventEx(self, callback: Callable[[str], None]) -> bool:
+        """
+        Register a callback for raw event data.
+
+        This provides access to the raw JSON event data from the SDK.
+        Use this when you need custom event handling or access to all event types.
+        This callback is called IN ADDITION to typed callbacks, not instead of.
+
+        Args:
+            callback: Function called with raw JSON event data string
+
+        Returns:
+            bool: True if registration succeeds
+        """
+        self._raw_event_callback = callback
+        self._setup_event_handler()
         return True
 
     def leave(self):

--- a/src/rtms/__init__.py
+++ b/src/rtms/__init__.py
@@ -270,6 +270,16 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
         try:
             payload = json.loads(body.decode('utf-8'))
+
+            # Validate required webhook fields
+            if not isinstance(payload.get('event'), str):
+                log_warn("webhook", "Received webhook payload missing required 'event' field")
+                self.send_response(400)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(b'{"error": "Invalid webhook payload: missing required event field"}')
+                return
+
             event_type = payload.get('event', 'unknown')
             log_info("webhook", f"Received event: {event_type}")
             log_debug("webhook", f"Received webhook payload: {payload}")

--- a/src/rtms/__init__.py
+++ b/src/rtms/__init__.py
@@ -23,6 +23,9 @@ from ._rtms import (
     # Session event constants
     SESSION_EVENT_ADD, SESSION_EVENT_STOP, SESSION_EVENT_PAUSE, SESSION_EVENT_RESUME,
 
+    # User event constants
+    USER_JOIN, USER_LEAVE,
+
     # Event types for subscribeEvent/unsubscribeEvent (used with onEventEx callback)
     # These match RTMS_EVENT_TYPE from Zoom's C SDK
     EVENT_UNDEFINED, EVENT_FIRST_PACKET_TIMESTAMP,
@@ -1281,6 +1284,10 @@ __all__ = [
     "SESSION_EVENT_STOP",
     "SESSION_EVENT_PAUSE",
     "SESSION_EVENT_RESUME",
+
+    # Constants - User Events
+    "USER_JOIN",
+    "USER_LEAVE",
 
     # Constants - Event Types (for subscribeEvent/onEventEx)
     # These match RTMS_EVENT_TYPE from Zoom's C SDK

--- a/src/rtms/__init__.py
+++ b/src/rtms/__init__.py
@@ -579,6 +579,7 @@ class Client(_ClientBase):
 
     def join(self,
              meeting_uuid: str = None,
+             webinar_uuid: str = None,
              session_id: str = None,
              rtms_stream_id: str = None,
              server_urls: str = None,
@@ -596,6 +597,7 @@ class Client(_ClientBase):
 
         Args:
             meeting_uuid (str): Meeting UUID (for Meeting SDK events)
+            webinar_uuid (str): Webinar UUID (for Webinar events)
             session_id (str): Session ID (for Video SDK events) - used when meeting_uuid is not provided
             rtms_stream_id (str): RTMS stream ID
             server_urls (str): Server URLs (comma-separated)
@@ -617,6 +619,7 @@ class Client(_ClientBase):
                 # If additional kwargs are provided, merge them with the named parameters
                 params = {
                     'meeting_uuid': meeting_uuid,
+                    'webinar_uuid': webinar_uuid,
                     'session_id': session_id,
                     'rtms_stream_id': rtms_stream_id,
                     'server_urls': server_urls,
@@ -638,6 +641,7 @@ class Client(_ClientBase):
             # Otherwise, use the parameters directly
             return self._join_with_params(
                 meeting_uuid=meeting_uuid,
+                webinar_uuid=webinar_uuid,
                 session_id=session_id,
                 rtms_stream_id=rtms_stream_id,
                 server_urls=server_urls,
@@ -681,6 +685,7 @@ class Client(_ClientBase):
         try:
             # Extract parameters with defaults
             meeting_uuid = params.get('meeting_uuid')
+            webinar_uuid = params.get('webinar_uuid')
             session_id = params.get('session_id')
             rtms_stream_id = params.get('rtms_stream_id')
             server_urls = params.get('server_urls')
@@ -691,11 +696,11 @@ class Client(_ClientBase):
             secret = params.get('secret', os.getenv('ZM_RTMS_SECRET'))
             poll_interval = params.get('poll_interval', 10)
 
-            # Use meeting_uuid for Meeting SDK events, session_id for Video SDK events
-            instance_id = meeting_uuid or session_id
+            # Use meeting_uuid for Meeting SDK, webinar_uuid for Webinar, session_id for Video SDK
+            instance_id = meeting_uuid or webinar_uuid or session_id
 
             if not instance_id:
-                raise ValueError("Either meeting_uuid or session_id is required")
+                raise ValueError("Either meeting_uuid, webinar_uuid, or session_id is required")
             if not rtms_stream_id:
                 raise ValueError("RTMS Stream ID is required")
             if not server_urls:
@@ -712,8 +717,8 @@ class Client(_ClientBase):
             # Store polling interval
             self._polling_interval = poll_interval
 
-            # Join the meeting/session
-            log_info("client", f"Joining {'meeting' if meeting_uuid else 'session'}: {instance_id}")
+            # Join the meeting/webinar/session
+            log_info("client", f"Joining {'meeting' if meeting_uuid else 'webinar' if webinar_uuid else 'session'}: {instance_id}")
             super().join(instance_id, rtms_stream_id, signature, server_urls, timeout)
 
             # Start polling thread

--- a/src/rtms/__init__.pyi
+++ b/src/rtms/__init__.pyi
@@ -442,6 +442,13 @@ SESSION_EVENT_PAUSE: int
 SESSION_EVENT_RESUME: int
 
 # ============================================================================
+# Constants - User Events
+# ============================================================================
+
+USER_JOIN: int
+USER_LEAVE: int
+
+# ============================================================================
 # Constants - Event Types (for subscribeEvent/unsubscribeEvent)
 # These match RTMS_EVENT_TYPE from Zoom's C SDK
 # ============================================================================

--- a/src/rtms/__init__.pyi
+++ b/src/rtms/__init__.pyi
@@ -218,6 +218,7 @@ class Client:
     def join(
         self,
         meeting_uuid: Optional[str] = None,
+        webinar_uuid: Optional[str] = None,
         session_id: Optional[str] = None,
         rtms_stream_id: Optional[str] = None,
         server_urls: Optional[str] = None,
@@ -232,6 +233,7 @@ class Client:
         """Join a Zoom RTMS session.
 
         For Meeting SDK events (meeting.rtms_started), use meeting_uuid.
+        For Webinar events (webinar.rtms_started), use webinar_uuid.
         For Video SDK events (session.rtms_started), use session_id.
         """
         ...

--- a/src/rtms/__init__.pyi
+++ b/src/rtms/__init__.pyi
@@ -349,6 +349,20 @@ class Client:
         """
         ...
 
+    def onMediaConnectionInterrupted(self, callback: Callable[[int], None]) -> bool:
+        """
+        Register media connection interrupted event callback.
+
+        This automatically subscribes to EVENT_MEDIA_CONNECTION_INTERRUPTED.
+
+        Args:
+            callback: Function called with (timestamp,) when media connection is interrupted
+
+        Returns:
+            True if callback was set successfully
+        """
+        ...
+
     def onEventEx(self, callback: EventExCallback) -> bool:
         """
         Register raw JSON event callback.


### PR DESCRIPTION
## Description

Release v1.0.3 of the Zoom RTMS SDK. This release adds webinar UUID support, a new `onMediaConnectionInterrupted` callback, and fixes several bugs across Node.js and Python bindings including a release crash on ended sessions, video params being overwritten by audio params, Express middleware compatibility in the webhook handler, webhook schema validation, and Python event callback coexistence.

## Related Issues

Fixes #93, Fixes #94, Fixes #95, Fixes #96

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests (adding or improving tests)
- [x] Build changes

## Affected Components
- [x] Core C++ implementation
- [x] Node.js bindings
- [x] Python bindings
- [ ] Go bindings
- [ ] Build system
- [x] Documentation
- [ ] Examples
- [ ] Other (please specify)

## Testing Performed

- Unit tests pass locally for both Node.js and Python bindings (`task test:js`, `task test:py`)
- Docker-based Linux tests pass (`docker compose run --rm test-js`, `docker compose run --rm test-py`)
- Manual testing of webhook handler with Express middleware (pre-parsed `req.body`)
- Manual testing of `webinar_uuid` join parameter
- Manual testing of `onMediaConnectionInterrupted` callback registration
- Verified `release()` no longer throws when session has already ended
- Verified `setAudioParams()` followed by `setVideoParams()` preserves both configurations

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

### Summary of Changes

**Bug Fixes:**
- **Release crash on ended sessions** (#93): `release()` no longer throws when the meeting has already ended; `RTMS_SDK_NOT_EXIST` is treated as success.
- **Video params ignored after audio params** (#94): Individual param setters (`setAudioParams`, `setVideoParams`) no longer trigger default-filling logic that overwrites the other configuration.
- **Express middleware compatibility** (#96): `createWebhookHandler` reads from `req.body` when pre-parsed by middleware like `express.json()`, preventing hangs.
- **Webhook schema validation** (#95): Webhook handlers validate the `event` field is present and return 400 Bad Request for invalid payloads.
- **Python event callback coexistence**: Refactored to a shared event dispatcher so `onParticipantEvent`, `onActiveSpeakerEvent`, and `onSharingEvent` can all be registered simultaneously.
- **Fixed Webinar UUID support** (`webinar_uuid` parameter in `join()`): Enables connecting to Zoom Webinar RTMS streams via `webinar.rtms_started` events. Resolution priority: `meeting_uuid` > `webinar_uuid` > `session_id`.
- **Connected `onMediaConnectionInterrupted` callback**: High-level callback for `EVENT_MEDIA_CONNECTION_INTERRUPTED` events with auto-subscription in both Node.js and Python.
- **`USER_JOIN` / `USER_LEAVE` constants**: Now exported for use in user update callbacks.